### PR TITLE
Update language

### DIFF
--- a/russian/goals_lang.php
+++ b/russian/goals_lang.php
@@ -8,47 +8,47 @@ $lang['goals_tracking']                                                 = 'От�
 $lang['new_goal']                                                       = 'Новая цель';
 $lang['goal_lowercase']                                                 = 'цель';
 $lang['goal_start_date']                                                = 'Дата начала';
-$lang['goal_end_date']                                                  = 'Дата окончания';
+$lang['goal_end_date']                                                  = 'Дата завершения';
 $lang['goal_subject']                                                   = 'Тема';
 $lang['goal_description']                                               = 'Описание';
 $lang['goal_type']                                                      = 'Тип цели';
 $lang['goal_achievement']                                               = 'Достижение';
 $lang['goal_contract_type']                                             = 'Тип договора';
-$lang['goal_notify_when_fail']                                          = 'Сообщить сотрудникам, если цель не удалось достичь';
-$lang['goal_notify_when_achieve']                                       = 'Сообщить сотрудникам, если цель достигнута';
+$lang['goal_notify_when_fail']                                          = 'Уведомить сотрудников, если цель не удалось достичь';
+$lang['goal_notify_when_achieve']                                       = 'Уведомить сотрудников, если цель достигнута';
 $lang['goal_progress']                                                  = 'Прогресс';
-$lang['goal_total']                                                     = 'Итого: %s';
-$lang['goal_result_heading']                                            = 'Прогресс цели';
+$lang['goal_total']                                                     = 'Всего: %s';
+$lang['goal_result_heading']                                            = 'Ход продвижения';
 $lang['goal_income_shown_in_base_currency']                             = 'Общая сумма дохода отображается в базовой валюте';
-$lang['goal_notify_when_end_date_arrives']                              = 'Сотрудники будут уведомлены, в дату окончания (Requires CRON).';
+$lang['goal_notify_when_end_date_arrives']                              = 'Сотрудники будут уведомлены по завершении срока (необходим CRON)';
 $lang['goal_staff_members_notified_about_achievement']                  = 'Сотрудники уведомлены об успехе';
 $lang['goal_staff_members_notified_about_failure']                      = 'Сотрудники уведомлены о неудаче';
 $lang['goal_notify_staff_manually']                                     = 'Уведомить сотрудников вручную';
-$lang['goal_notify_staff_notified_manually_success']                    = 'Сотрудники уведомлены о результате цели';
+$lang['goal_notify_staff_notified_manually_success']                    = 'Сотрудники уведомлены об этом результате';
 $lang['goal_notify_staff_notified_manually_fail']                       = 'Не удалось уведомить сотрудников об этом результате';
-$lang['goal_achieved']                                                  = 'Выполнено';
-$lang['goal_failed']                                                    = 'Не выполнено';
-$lang['goal_close']                                                     = 'Близко к цели';
-$lang['goal_type_total_income']                                         = 'Достигните совокупного дохода';
-$lang['goal_type_convert_leads']                                        = 'Конвертировать X Лидов';
-$lang['goal_type_increase_customers_without_leads_conversions']         = 'Увеличить кол-во клиентов';
-$lang['goal_type_increase_customers_without_leads_conversions_subtext'] = 'Не включая конвертирование лидов';
-$lang['goal_type_increase_customers_with_leads_conversions']            = 'Увеличить кол-во клиентов';
+$lang['goal_achieved']                                                  = 'Успешно';
+$lang['goal_failed']                                                    = 'Провал';
+$lang['goal_close']                                                     = 'Почти что';
+$lang['goal_type_total_income']                                         = 'Достигнуть совокупного дохода';
+$lang['goal_type_convert_leads']                                        = 'Конвертировать энное количество лидов';
+$lang['goal_type_increase_customers_without_leads_conversions']         = 'Увеличить число клиентов';
+$lang['goal_type_increase_customers_without_leads_conversions_subtext'] = 'Исключая конвертирование лидов';
+$lang['goal_type_increase_customers_with_leads_conversions']            = 'Увеличить число клиентов';
 $lang['goal_type_increase_customers_with_leads_conversions_subtext']    = 'Включая конвертирование лидов';
-$lang['goal_type_make_contracts_by_type_calc_database']                 = 'Сделать контракты по типу';
-$lang['goal_type_make_contracts_by_type_calc_database_subtext']         = 'Рассчитывается с даты, добавленной в базу данных';
-$lang['goal_type_make_contracts_by_type_calc_date']                     = 'Сделать контракты по типу';
-$lang['goal_type_make_contracts_by_type_calc_date_subtext']             = 'Рассчитывается с даты начала контракта';
-$lang['goal_type_total_estimates_converted']                            = 'X Estimates Conversion ';
-$lang['goal_type_total_estimates_converted_subtext']                    = 'Will be taken only estimates that will be converted to invoices';
+$lang['goal_type_make_contracts_by_type_calc_database']                 = 'Заключить договоров по типу';
+$lang['goal_type_make_contracts_by_type_calc_database_subtext']         = 'Рассчитывается с даты добавления в базу данных';
+$lang['goal_type_make_contracts_by_type_calc_date']                     = 'Заключить договоров по типу';
+$lang['goal_type_make_contracts_by_type_calc_date_subtext']             = 'Рассчитывается с даты начала действия договора';
+$lang['goal_type_total_estimates_converted']                            = 'Конвертировать энное количество смет';
+$lang['goal_type_total_estimates_converted_subtext']                    = 'Будут учтены только сметы конвертированные в счета';
 $lang['goal_type_income_subtext']                                       = 'Доход будет рассчитываться в вашей базовой валюте (не конвертированной)';
-$lang['not_goal_message_success']                                       = 'Поздравляем! Мы выполнили поставленную цель.<br /> Тип цели: %s
+$lang['not_goal_message_success']                                       = 'Поздравляем! Мы достигли поставленную цель.<br /> Тип цели: %s
 <br />Поставленная цель: %s
 <br />Итог достижения: %s
 <br />Дата начала: %s
-<br />Дата окончания: %s';
-$lang['not_goal_message_failed'] = 'Мы не смогли достичь цели!<br /> Тип цели: %s
-<br />Достижение цели: %s
-<br />Всего достижений: %s
+<br />Дата завершения: %s';
+$lang['not_goal_message_failed'] = 'Мы не смогли достичь поставленную цель!<br /> Тип цели: %s
+<br />Поставленная цель: %s
+<br />Итог достижения: %s
 <br />Дата начала: %s
-<br />Дата окончания: %s';
+<br />Дата завершения: %s';


### PR DESCRIPTION
Translated missed strings. Some lexical and grammar corrections with a touch of humanity instead auto translation. On lines 29-31 translation replaced with short enough synonyms to avoid of breaking design.

Btw, it was so hard to resist place 'br' tag after translated text for 'goal_result_heading' on line 21. Just to let you know...